### PR TITLE
141617737 edit foods aw

### DIFF
--- a/foods.html
+++ b/foods.html
@@ -6,6 +6,7 @@
     crossorigin="anonymous"></script>
   <script src="./lib/foods.js"></script>
   <script src="./lib/filter_foods.js"></script>
+  <script src="./lib/edit-foods.js"></script>
   <script src="./lib/common.js"></script>
   <link type="text/css" rel="stylesheet" href="./lib/foods.css" >
   <link type="text/css" rel="stylesheet" href="./lib/common.css" >

--- a/lib/edit-foods.js
+++ b/lib/edit-foods.js
@@ -1,4 +1,4 @@
-$('document').ready( function() {
+$(document).ready(function() {
   $('body').on('click', '.food-row td', function() { 
     var $el = $(this);
     var $input = $('<input/>').val( $el.text() );

--- a/lib/edit-foods.js
+++ b/lib/edit-foods.js
@@ -1,14 +1,23 @@
 $(document).ready(function() {
   $('body').on('click', '.food-row td', function() { 
-    var $el = $(this);
-    var $input = $('<input/>').val( $el.text() );
-    $el.replaceWith( $input );
+    var $td = $(this);
+    var food = localStorage.getItem( $td.text() );
+    var $input = $('<input/>').val( $td.text() );
+    $td.replaceWith( $input );
     
-    var save = function() {  
-      var $td = $('<td />').text($input.val() );
-      $input.replaceWith($td);
+    var save = function() {
+      localStorage.setItem($input.val(), `<tr class='food-row'>
+                <td class='food-name'>` + $input.val() + `</td>
+                <td class='food-calories'>` + $input.siblings().first().text()  + `</td>
+                <td class='food-delete'><button>-</button></td>
+              </tr>`); 
+      var $td = localStorage.getItem($input.val());
+      $input.parent().remove();
+      $('#food-list tbody').prepend($td);
     };
-
+    
     $input.one('blur', save).focus();
+    localStorage.removeItem($td.text());
   });
-})
+});
+

--- a/lib/edit-foods.js
+++ b/lib/edit-foods.js
@@ -21,5 +21,42 @@ $(document).ready(function() {
     
     $input.one('blur', save).focus();
   });
+
+  $('tbody').on('click', '.food-row td.food-calories', function() {
+    var $td = $(this);
+    var currentFoods = JSON.parse(localStorage.getItem( "food-items" ));
+    var food = $.grep(currentFoods, function(food) { 
+      return food.name === $td.text() || food.calories === $td.text(); 
+    })[0];
+    currentFoods = $.grep(currentFoods, function(notFood) {
+      return notFood != food;
+    });
+    var $input = $('<input/>').val( $td.text() );
+    $td.replaceWith( $input );
+  
+    var save = function() {
+      food.calories = $input.val();
+      currentFoods.push(food);
+      localStorage.setItem('food-items', JSON.stringify(currentFoods)); 
+      $input.parent().remove();
+      formatFoodItemTable(food.name, food.calories);
+    };
+    
+    $input.one('blur', save).focus();
+  });
+
+
 });
+
+function findEditedFood(currentFoods,foodData) {
+  $.grep(currentFoods, function(food) { 
+    return food.name === foodData || food.calories === foodData; 
+  })[0];
+};
+
+function pullOutEditedFood(currentFoods,food){
+  $.grep(currentFoods, function(notFood) {
+    return notFood != food;
+  });
+};
 

--- a/lib/edit-foods.js
+++ b/lib/edit-foods.js
@@ -1,18 +1,14 @@
 $(document).ready(function() {
-  $('tbody').on('click', '.food-row td.food-name', function() { 
+  $('tbody').on('click', '.food-row td', function() { 
     var $td = $(this);
+    var dataName = $td.attr('class');
     var currentFoods = JSON.parse(localStorage.getItem( "food-items" ));
-    var food = $.grep(currentFoods, function(food) { 
-      return food.name === $td.text() || food.calories === $td.text(); 
-    })[0];
-    currentFoods = $.grep(currentFoods, function(notFood) {
-      return notFood != food;
-    });
-    var $input = $('<input/>').val( $td.text() );
-    $td.replaceWith( $input );
+    var food = findEditedFood(currentFoods, $td.text());
+    currentFoods = pullOutEditedFood(currentFoods, food);
+    var $input = replaceTdWithInput($td); 
     
     var save = function() {
-      food.name = $input.val();
+      updateFood(food, dataName, $input.val());
       currentFoods.push(food);
       localStorage.setItem('food-items', JSON.stringify(currentFoods)); 
       $input.parent().remove();
@@ -21,41 +17,31 @@ $(document).ready(function() {
     
     $input.one('blur', save).focus();
   });
-
-  $('tbody').on('click', '.food-row td.food-calories', function() {
-    var $td = $(this);
-    var currentFoods = JSON.parse(localStorage.getItem( "food-items" ));
-    var food = $.grep(currentFoods, function(food) { 
-      return food.name === $td.text() || food.calories === $td.text(); 
-    })[0];
-    currentFoods = $.grep(currentFoods, function(notFood) {
-      return notFood != food;
-    });
-    var $input = $('<input/>').val( $td.text() );
-    $td.replaceWith( $input );
-  
-    var save = function() {
-      food.calories = $input.val();
-      currentFoods.push(food);
-      localStorage.setItem('food-items', JSON.stringify(currentFoods)); 
-      $input.parent().remove();
-      formatFoodItemTable(food.name, food.calories);
-    };
-    
-    $input.one('blur', save).focus();
-  });
-
 
 });
 
+function updateFood(food, dataName, newData){
+  if (dataName === 'food-name') {  
+    food.name = newData 
+  } else {
+    food.calories = newData
+  }
+};
+
+function replaceTdWithInput($td) {
+  var $input = $('<input/>').val($td.text());
+  $td.replaceWith( $input ); 
+  return $input;
+};
+
 function findEditedFood(currentFoods,foodData) {
-  $.grep(currentFoods, function(food) { 
+  return $.grep(currentFoods, function(food) { 
     return food.name === foodData || food.calories === foodData; 
   })[0];
 };
 
 function pullOutEditedFood(currentFoods,food){
-  $.grep(currentFoods, function(notFood) {
+  return $.grep(currentFoods, function(notFood) {
     return notFood != food;
   });
 };

--- a/lib/edit-foods.js
+++ b/lib/edit-foods.js
@@ -1,0 +1,14 @@
+$('document').ready( function() {
+  $('body').on('click', '.food-row td', function() { 
+    var $el = $(this);
+    var $input = $('<input/>').val( $el.text() );
+    $el.replaceWith( $input );
+    
+    var save = function() {  
+      var $td = $('<td />').text($input.val() );
+      $input.replaceWith($td);
+    };
+
+    $input.one('blur', save).focus();
+  });
+})

--- a/lib/edit-foods.js
+++ b/lib/edit-foods.js
@@ -1,23 +1,25 @@
 $(document).ready(function() {
-  $('body').on('click', '.food-row td', function() { 
+  $('tbody').on('click', '.food-row td.food-name', function() { 
     var $td = $(this);
-    var food = localStorage.getItem( $td.text() );
+    var currentFoods = JSON.parse(localStorage.getItem( "food-items" ));
+    var food = $.grep(currentFoods, function(food) { 
+      return food.name === $td.text() || food.calories === $td.text(); 
+    })[0];
+    currentFoods = $.grep(currentFoods, function(notFood) {
+      return notFood != food;
+    });
     var $input = $('<input/>').val( $td.text() );
     $td.replaceWith( $input );
     
     var save = function() {
-      localStorage.setItem($input.val(), `<tr class='food-row'>
-                <td class='food-name'>` + $input.val() + `</td>
-                <td class='food-calories'>` + $input.siblings().first().text()  + `</td>
-                <td class='food-delete'><button>-</button></td>
-              </tr>`); 
-      var $td = localStorage.getItem($input.val());
+      food.name = $input.val();
+      currentFoods.push(food);
+      localStorage.setItem('food-items', JSON.stringify(currentFoods)); 
       $input.parent().remove();
-      $('#food-list tbody').prepend($td);
+      formatFoodItemTable(food.name, food.calories);
     };
     
     $input.one('blur', save).focus();
-    localStorage.removeItem($td.text());
   });
 });
 

--- a/lib/foods.css
+++ b/lib/foods.css
@@ -32,3 +32,11 @@ td.food-delete {
 #create-form {
   text-align:right;
 }
+
+.food-row input {
+  height: 30px;
+  font-size: 16px;
+  border:solid black 1px;
+  margin:0;
+  padding:4px;
+}


### PR DESCRIPTION
This PR begins the edit and save food stories. It currently will only work for the food name `<td>`, but it illustrates the desired effect. Updating it for the calories should just be a matter of DOM traversal, but I wanted to get some more eyes on this before I move forward. It seems like there must be a better way.

I think we might want to address the way we are saving objects in localStorage. Currently, we have a key of the food's name and the html for the food's `<tr>`. This means that the entire object needs to change if the food's name changes. Also, it makes it difficult to access the calorie value. It looks like we'll need to do some calculations later with these numbers, so exposing them now might be advantageous. We can create an object that looks more like `{"banana": {"name": "Banana", "calories": "35"}}`. This still doesn't change our naming problem, though...

[#141617737], [##141617739]
@case-eee